### PR TITLE
Added a package image that can be used to create buildpackages

### DIFF
--- a/Dockerfile.package
+++ b/Dockerfile.package
@@ -1,0 +1,37 @@
+FROM golang:latest as build-stage
+
+RUN apt-get update && apt-get install -y --no-install-recommends upx
+
+WORKDIR /src
+ENV GO111MODULE=on CGO_ENABLED=0
+RUN go get -u -ldflags="-s -w" github.com/google/go-containerregistry/cmd/crane
+RUN which crane
+
+RUN curl \
+      --output /bin/yj \
+      --location \
+      --show-error \
+      --silent \
+      "https://github.com/sclevine/yj/releases/download/v5.0.0/yj-linux" \
+    && chmod +x /bin/yj
+
+ENV PACK_VERSION 0.14.1
+RUN curl \
+      --location \
+      --show-error \
+      --silent \
+      "https://github.com/buildpacks/pack/releases/download/v${PACK_VERSION}/pack-v${PACK_VERSION}-linux.tgz" \
+      | tar -C /bin/ -xzv pack
+
+FROM ubuntu:latest
+
+RUN apt-get update && apt-get install -y --no-install-recommends jq
+
+COPY --from=build-stage /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=build-stage /go/bin/crane /bin/crane
+COPY --from=build-stage /bin/yj /bin/yj
+COPY --from=build-stage /bin/pack /bin/pack
+
+COPY sbin/package.sh /bin/package
+RUN chmod +x /bin/package
+ENTRYPOINT ["/bin/package"]

--- a/sbin/package.sh
+++ b/sbin/package.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# create the package name with version
+
+if [ ! -f buildpack.toml ]; then
+  echo "missing buildpack.toml!"
+  exit 1
+fi
+
+version="$(cat buildpack.toml | yj -t | jq -r .buildpack.version)"
+echo "::set-output name=version::${version}"
+echo "Selected version ${version} from buildpack.toml"
+
+package="${INPUT_PACKAGE}:${version}"
+
+if [ ! -f package.toml ]; then
+  echo "[buildpack]\nuri = \".\"" > package.toml
+fi
+
+if [[ -n "${INPUT_PUBLISH+x}" ]]; then
+  pack package-buildpack \
+    "${package}" \
+    --config package.toml \
+    --publish
+else
+  pack package-buildpack \
+    "${package}" \
+    --config package.toml
+fi
+
+echo "::set-output name=digest::$(crane digest "${package}")"


### PR DESCRIPTION
This doesn't really work because:
* when `publish: "true"` it can't use a docker login from a previous step
* when not publishing, the image would be lost in the next step. maybe there's a way to store it locally, but this would be inefficent