### PR TITLE
Adding version to buildpacks/github-actions/setup-pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ The setup-pack action adds [crane][crane], [`jq`][jq], [`pack`][pack], and [`yj`
 [yj]:    https://github.com/sclevine/yj
 
 ```yaml
-uses: buildpacks/github-actions/setup-pack
+uses: buildpacks/github-actions/setup-pack@v4.1.0
 ```
 
 #### Inputs <!-- omit in toc -->


### PR DESCRIPTION
Fixes https://github.com/buildpacks/github-actions/issues/37

Using the pinned version my build https://github.com/jonashackt/spring-boot-buildpack/runs/2146471906?check_suite_focus=true worked as expected.

Using only the `@v4` resulted in [the following error](https://github.com/jonashackt/spring-boot-buildpack/runs/2146458399?check_suite_focus=true): 
```
Error: Unable to resolve action `buildpacks/github-actions@v4`, unable to find version `v4`
```