### PR TITLE
adds workflow to trigger creation of PR in buildpacks/registry-index and fixes #40

### DIFF
--- a/.github/workflows/action-registry-index-update-release.yml
+++ b/.github/workflows/action-registry-index-update-release.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@v1.1.13
         with:
           token: ${{ secrets.DISTRIBUTION_GITHUB_TOKEN }}
           repository: buildpacks/registry-index

--- a/.github/workflows/action-registry-index-update-release.yml
+++ b/.github/workflows/action-registry-index-update-release.yml
@@ -1,0 +1,14 @@
+name: Creating the PR to update the version of buildpacks/github-actions on buildpacks/registry-index
+on:
+  release:
+    types: [published]
+jobs:
+  myEvent:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.DISTRIBUTION_GITHUB_TOKEN }}
+          repository: buildpacks/registry-index
+          event-type: release-event


### PR DESCRIPTION
This PR adds and fixes #40 :

- workflow that will dispatch event on https://github.com/buildpacks/registry-index on every release of buildpacks/github-actions
- this will trigger the workflow in registry-index to create a PR to update the https://github.com/buildpacks/registry-index/blob/main/.github/workflows/register-buildpack.yml

Thus the above PR automates the entire process of fixing the release version on registry-index on every release of buildpacks/github-actions, therefore, fixes #40

Signed-off-by: Mritunjay Sharma <mritunjaysharma394@gmail.com>