### PR TITLE
Update default crane version

### DIFF
--- a/setup-pack/action.yml
+++ b/setup-pack/action.yml
@@ -6,7 +6,7 @@ inputs:
   crane-version:
     description: 'The version of crane to install'
     required:    false
-    default:     '0.1.4'
+    default:     '0.6.0'
   jq-version:
     description: 'The version of jq to install'
     required:    false


### PR DESCRIPTION
v0.6.0 is the latest (3 months ago). v0.1.4 is nearly a year old.