### PR TITLE
Move tool installation from `setup-pack` to a new `setup-tools` action

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
     - [Verify Namespace Owner Action](#verify-namespace-owner-action)
     - [Yank Entry Action](#yank-entry-action)
   - [Setup pack CLI Action](#setup-pack-cli-action)
+  - [Setup Tools Action](#setup-tools-action)
   - [License](#license)
 
 ## Buildpack
@@ -178,7 +179,7 @@ with:
 | `add-if-missing` | Whether to add the current user as the owner of the namespace if that namespace does not exist. (Optional. Default `false`)
 
 ### Yank Entry Action
-The `registry/yank-entry` yanks an entry from the [Buildpack Registry Index][bri].
+The `registry/yank-entry` action yanks an entry from the [Buildpack Registry Index][bri].
 
 ```yaml
 uses: docker://ghcr.io/buildpacks/actions/registry/yank-entry
@@ -202,24 +203,34 @@ with:
 | `version` | The version of the buildpack to register.
 
 ## Setup pack CLI Action
-The setup-pack action adds [crane][crane], [`jq`][jq], [`pack`][pack], and [`yj`][yj] to the environment.
+The `setup-pack` action adds [`pack`][pack] to the environment.
 
-[crane]: https://github.com/google/go-containerregistry/tree/master/cmd/crane
-[jq]:    https://stedolan.github.io/jq/
 [pack]:  https://github.com/buildpacks/pack
-[yj]:    https://github.com/sclevine/yj
 
 ```yaml
-uses: buildpacks/github-actions/setup-pack@v4.1.0
+uses: buildpacks/github-actions/setup-pack@v5.0.0
 ```
 
 #### Inputs <!-- omit in toc -->
 | Parameter | Description
 | :-------- | :----------
-| `crane-version` | Optional version of [`crane`][crane] to install. Defaults to latest release.
-| `jq-version` | Optional version of [`jq`][jq] to install. Defaults to latest release.
 | `pack-version` | Optional version of [`pack`][pack] to install. Defaults to latest release.
-| `yj-version` | Optional version of [`yj`][yj] to install. Defaults to latest release.
+
+## Setup Tools Action
+The `setup-tools` action adds [crane][crane] and [`yj`][yj] to the environment.
+
+[crane]: https://github.com/google/go-containerregistry/tree/master/cmd/crane
+[yj]:    https://github.com/sclevine/yj
+
+```yaml
+uses: buildpacks/github-actions/setup-tools@v5.0.0
+```
+
+#### Inputs <!-- omit in toc -->
+| Parameter | Description
+| :-------- | :----------
+| `crane-version` | Optional version of [`crane`][crane] to install. Defaults to `0.12.1`.
+| `yj-version` | Optional version of [`yj`][yj] to install. Defaults to `5.1.0`.
 
 ## License
 This library is released under version 2.0 of the [Apache License][a].

--- a/setup-pack/action.yml
+++ b/setup-pack/action.yml
@@ -1,29 +1,17 @@
 name:        'Setup pack CLI'
-description: 'Setup the Cloud Native Buildpacks pack CLI as well as other useful tools and add them to $PATH'
+description: 'Install the Cloud Native Buildpacks pack CLI and add it to $PATH'
 author:      'Cloud Native Buildpacks'
 
 inputs:
-  crane-version:
-    description: 'The version of crane to install'
-    required:    false
-    default:     '0.6.0'
-  jq-version:
-    description: 'The version of jq to install'
-    required:    false
-    default:     '1.6'
   pack-version:
     description: 'The version of pack to install'
     required:    false
     default:     '0.28.0'
-  yj-version:
-    description: 'The version of yj to install'
-    required:    false
-    default:     '5.0.0'
 
 runs:
   using: "composite"
   steps:
-  - name:  Setup pack CLI
+  - name:  Install pack CLI
     shell: bash
     run:   |
            #!/usr/bin/env bash
@@ -32,33 +20,6 @@ runs:
 
            mkdir -p "${HOME}"/bin
            echo "PATH=${HOME}/bin:${PATH}" >> "${GITHUB_ENV}"
-
-           CRANE_VERSION=${{ inputs.crane-version }}
-           echo "Installing crane ${CRANE_VERSION}"
-           curl \
-             --show-error \
-             --silent \
-             --location \
-             --fail \
-             --retry 3 \
-             --connect-timeout 5 \
-             --max-time 60 \
-             "https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" \
-           | tar -C "${HOME}/bin" -xz crane
-
-           JQ_VERSION=${{ inputs.jq-version }}
-           echo "Installing jq ${JQ_VERSION}"
-           curl \
-             --show-error \
-             --silent \
-             --location \
-             --fail \
-             --retry 3 \
-             --connect-timeout 5 \
-             --max-time 60 \
-             --output "${HOME}/bin/jq" \
-             "https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64"
-           chmod +x "${HOME}"/bin/jq
 
            PACK_VERSION=${{ inputs.pack-version }}
            echo "Installing pack ${PACK_VERSION}"
@@ -72,17 +33,3 @@ runs:
              --max-time 60 \
              "https://github.com/buildpacks/pack/releases/download/v${PACK_VERSION}/pack-v${PACK_VERSION}-linux.tgz" \
            | tar -C "${HOME}/bin" -xz pack
-
-           YJ_VERSION=${{ inputs.yj-version }}
-           echo "Installing yj ${YJ_VERSION}"
-           curl \
-             --show-error \
-             --silent \
-             --location \
-             --fail \
-             --retry 3 \
-             --connect-timeout 5 \
-             --max-time 60 \
-             --output "${HOME}/bin/yj" \
-             "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
-           chmod +x "${HOME}"/bin/yj

--- a/setup-tools/action.yml
+++ b/setup-tools/action.yml
@@ -1,0 +1,53 @@
+name:        'Setup tools'
+description: 'Install the tools crane and yq, and add them to $PATH'
+author:      'Cloud Native Buildpacks'
+
+inputs:
+  crane-version:
+    description: 'The version of crane to install'
+    required:    false
+    default:     '0.12.1'
+  yj-version:
+    description: 'The version of yj to install'
+    required:    false
+    default:     '5.1.0'
+
+runs:
+  using: "composite"
+  steps:
+  - name:  Install additional buildpack management tools
+    shell: bash
+    run:   |
+           #!/usr/bin/env bash
+
+           set -euo pipefail
+
+           mkdir -p "${HOME}"/bin
+           echo "PATH=${HOME}/bin:${PATH}" >> "${GITHUB_ENV}"
+
+           CRANE_VERSION=${{ inputs.crane-version }}
+           echo "Installing crane ${CRANE_VERSION}"
+           curl \
+             --show-error \
+             --silent \
+             --location \
+             --fail \
+             --retry 3 \
+             --connect-timeout 5 \
+             --max-time 60 \
+             "https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" \
+           | tar -C "${HOME}/bin" -xz crane
+
+           YJ_VERSION=${{ inputs.yj-version }}
+           echo "Installing yj ${YJ_VERSION}"
+           curl \
+             --show-error \
+             --silent \
+             --location \
+             --fail \
+             --retry 3 \
+             --connect-timeout 5 \
+             --max-time 60 \
+             --output "${HOME}/bin/yj" \
+             "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
+           chmod +x "${HOME}"/bin/yj


### PR DESCRIPTION
Previously the `setup-pack` action installed not only the Pack CLI, but also three additional tools: `crane`, `jq` and `yj`.

These additional tools are only needed in a subset of cases, however there was no way to prevent their installation.

Now, the `setup-pack` action only installs the Pack CLI, and a new `setup-tools` action has been added, which installs `crane` and `yj`. This new action does not install `jq` (unlike the previous `setup-pack` implementation), since `jq` is already installed in all of GitHub Actions' base images.

This will need to be released as a new major version of the action (ie: `5.0.0`), given it's a breaking change.

In addition, the default versions of tools have been bumped as follows:
- `crane`: `0.6.0` -> `0.12.1`
- `yj`: `5.0.0` -> `5.1.0`

Closes #121.

Signed-off-by: Ed Morley <501702+edmorley@users.noreply.github.com>