### PR TITLE
Support yj's updated download filename

### DIFF
--- a/setup-tools/action.yml
+++ b/setup-tools/action.yml
@@ -40,6 +40,11 @@ runs:
 
            YJ_VERSION=${{ inputs.yj-version }}
            echo "Installing yj ${YJ_VERSION}"
+           if [[ "${YJ_VERSION}" < "5.1.0" ]]; then
+             YJ_DOWNLOAD_FILENAME="yj-linux"
+           else
+             YJ_DOWNLOAD_FILENAME="yj-linux-amd64"
+           fi
            curl \
              --show-error \
              --silent \
@@ -49,5 +54,5 @@ runs:
              --connect-timeout 5 \
              --max-time 60 \
              --output "${HOME}/bin/yj" \
-             "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
+             "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/${YJ_DOWNLOAD_FILENAME}"
            chmod +x "${HOME}"/bin/yj


### PR DESCRIPTION
As of `yj` 5.1.0+ the filename of the asset attached to the GitHub release is now `yj-linux-arm64` instead of `yj-linux`.

For example:
https://github.com/sclevine/yj/releases/tag/v5.1.0
vs
https://github.com/sclevine/yj/releases/tag/v5.0.0

This change ensures that the new yj default (as of #164; which updated the default yj from `5.0.0` to `5.1.0`) is able to be downloaded, since currently the `setup-tools` action fails with:

```
Installing yj 5.1.0
curl: (22) The requested URL returned error: 404
Error: Process completed with exit code 22.
```

The bash string comparison of the semver version isn't ideal, but it doesn't feel worth adding further complexity given that:
- all `yj` releases so far use a full semver version (and not say an `X.Y` version)
- `yj` major releases are infrequent, so it's going to be a while before v10 is out (which would break the comparison) - by which point this backwards compatibiluty comparison can just be removed (and support for pre v5.1.0 removed).
- any failure modes will be fairly noisy/obvious, and won't result in a subtle bug.