### PR TITLE
Add arm64 support for setup-pack and setup-tools

### DIFF
--- a/setup-pack/action.yml
+++ b/setup-pack/action.yml
@@ -21,6 +21,11 @@ runs:
            mkdir -p "${HOME}"/bin
            echo "PATH=${HOME}/bin:${PATH}" >> "${GITHUB_ENV}"
 
+           PLATFORM="linux"
+           if [ $(arch) = "aarch64" ]; then
+              PLATFORM="linux-arm64"
+           fi
+
            PACK_VERSION=${{ inputs.pack-version }}
            echo "Installing pack ${PACK_VERSION}"
            curl \
@@ -31,5 +36,5 @@ runs:
              --retry 3 \
              --connect-timeout 5 \
              --max-time 60 \
-             "https://github.com/buildpacks/pack/releases/download/v${PACK_VERSION}/pack-v${PACK_VERSION}-linux.tgz" \
+             "https://github.com/buildpacks/pack/releases/download/v${PACK_VERSION}/pack-v${PACK_VERSION}-${PLATFORM}.tgz" \
            | tar -C "${HOME}/bin" -xz pack

--- a/setup-tools/action.yml
+++ b/setup-tools/action.yml
@@ -24,7 +24,11 @@ runs:
 
            mkdir -p "${HOME}"/bin
            echo "PATH=${HOME}/bin:${PATH}" >> "${GITHUB_ENV}"
-
+          
+           CRANE_PLATFORM="Linux_x86_64"
+           if [ $(arch) = "aarch64" ]; then
+              CRANE_PLATFORM="Linux_arm64"
+           fi
            CRANE_VERSION=${{ inputs.crane-version }}
            echo "Installing crane ${CRANE_VERSION}"
            curl \
@@ -35,15 +39,19 @@ runs:
              --retry 3 \
              --connect-timeout 5 \
              --max-time 60 \
-             "https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" \
+             "https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/go-containerregistry_${CRANE_PLATFORM}.tar.gz" \
            | tar -C "${HOME}/bin" -xz crane
 
            YJ_VERSION=${{ inputs.yj-version }}
            echo "Installing yj ${YJ_VERSION}"
+           YJ_DOWNLOAD_FILENAME="yj-linux"
            if [[ "${YJ_VERSION}" < "5.1.0" ]]; then
-             YJ_DOWNLOAD_FILENAME="yj-linux"
+             YJ_PLATFORM=""
            else
-             YJ_DOWNLOAD_FILENAME="yj-linux-amd64"
+             YJ_PLATFORM="-amd64"
+           fi
+           if [ $(arch) = "aarch64" ]; then
+              YJ_PLATFORM="-arm64"
            fi
            curl \
              --show-error \
@@ -54,5 +62,5 @@ runs:
              --connect-timeout 5 \
              --max-time 60 \
              --output "${HOME}/bin/yj" \
-             "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/${YJ_DOWNLOAD_FILENAME}"
+             "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/${YJ_DOWNLOAD_FILENAME}${YJ_PLATFORM}"
            chmod +x "${HOME}"/bin/yj


### PR DESCRIPTION
This adds arm64 support for setup-pack and setup-tools.

# Testing verification

It is used in [this](https://github.com/jericop/cnb-builder/blob/main/.github/workflows/build-and-publish.yml) workflow.

* On an arm64 runner [here](https://github.com/jericop/cnb-builder/blob/main/.github/workflows/build-and-publish.yml#LL11C1-L14C1)
* On an amd64 runner [here](https://github.com/jericop/cnb-builder/blob/main/.github/workflows/build-and-publish.yml#LL57C4-L60C79)

Below are workflow logs showing that the actions work as expected.

* setup-pack
  * [arm64](https://github.com/jericop/cnb-builder/actions/runs/4853306486/jobs/8649319177#step:3:1)
  * [amd64](https://github.com/jericop/cnb-builder/actions/runs/4853306486/jobs/8649339153#step:3:1)
* setup-tools
  * [arm64](https://github.com/jericop/cnb-builder/actions/runs/4853306486/jobs/8649319177#step:4:1)
  * [amd64](https://github.com/jericop/cnb-builder/actions/runs/4853306486/jobs/8649339153#step:4:1)

