### PR TITLE
Increase timeouts for actions that rely on actions

### DIFF
--- a/registry/request-add-entry/cmd/main.go
+++ b/registry/request-add-entry/cmd/main.go
@@ -41,7 +41,7 @@ func main() {
 
 	gh := github.NewClient(oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(&oauth2.Token{AccessToken: t})))
 
-	strategy := retry.LimitTime(2*time.Minute,
+	strategy := retry.LimitTime(8*time.Minute,
 		retry.Exponential{
 			Initial:  time.Second,
 			MaxDelay: 30 * time.Second,

--- a/registry/request-yank-entry/cmd/main.go
+++ b/registry/request-yank-entry/cmd/main.go
@@ -41,7 +41,7 @@ func main() {
 
 	gh := github.NewClient(oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(&oauth2.Token{AccessToken: t})))
 
-	strategy := retry.LimitTime(2*time.Minute,
+	strategy := retry.LimitTime(8*time.Minute,
 		retry.Exponential{
 			Initial:  time.Second,
 			MaxDelay: 30 * time.Second,


### PR DESCRIPTION
The `registry/request-add-buildpack` and `registry/request-yank-buildpack` actions both rely on a synchronous check to ensure that the issue opened is also closed. The issue is only closed after the GitHub actions automation on `buildpacks/registry-index` finishes. However, it seems fairly common to see some instance queuing in GitHub actions. This PR changes the timeout for these actions to give a bit more time for the registry operations to complete.

Some examples of slower entries:

- https://github.com/buildpacks/registry-index/issues/5548 (3 minutes)
- https://github.com/buildpacks/registry-index/issues/5549 (4 minutes)
- https://github.com/buildpacks/registry-index/issues/5556 (8 minutes)
- https://github.com/buildpacks/registry-index/issues/5555 (8 minutes)
- https://github.com/buildpacks/registry-index/issues/5554 (8 minutes)

`registry/request-add-entry` with the default timeout of 2 minutes would have timed out for all of the above (in fact, one of mine did here: https://github.com/heroku/buildpacks-nodejs/actions/runs/5049524949/jobs/9059646026). I've increased the timeout to be just above the slowest of recent releases.