### PR TITLE
Remove upx from build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM golang:1.19 as build-stage
-
-RUN apt-get update && apt-get install -y --no-install-recommends upx
+FROM golang:1.20 as build-stage
 
 WORKDIR /src
 ENV GO111MODULE=on CGO_ENABLED=0
@@ -16,8 +14,6 @@ RUN go build \
   $SOURCE/main.go
 
 RUN strip /bin/action
-
-RUN upx -q -9 /bin/action
 
 FROM scratch
 COPY --from=build-stage /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
The `upx` package is no longer available for debian and newer versions of the `golang` base image. Because `upx` has caused us some issues locally with Crowdstrike, we are removing it from the build process.

This increases the size of the github-actions images by about  3MB each