### PR TITLE
Set required labels on the automatic pack version update PRs

### DIFF
--- a/.github/workflows/update-pack-version.yml
+++ b/.github/workflows/update-pack-version.yml
@@ -30,6 +30,9 @@ jobs:
             
             Release notes:
             https://github.com/buildpacks/pack/releases/tag/v${{ steps.version.outputs.new_version }}
+          labels: |
+            semver:patch
+            type:dependency-upgrade
           branch: update-version
           base: main
           signoff: true


### PR DESCRIPTION
When a new Pack CLI version is released, automation opens PRs like:
https://github.com/buildpacks/github-actions/pull/227

Currently the human reviewer has to remember to set the semver and type labels on that PR in order for the status checks to pass.

Now, the automation will set these itself on the PR.

See:
https://cloud-native.slack.com/archives/C0333LG7C9J/p1697499065289329?thread_ts=1697275064.492199&cid=C0333LG7C9J
https://github.com/peter-evans/create-pull-request#action-inputs