### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as build-stage
+FROM golang:1.22 as build-stage
 
 WORKDIR /src
 ENV GO111MODULE=on CGO_ENABLED=0


### PR DESCRIPTION
Bump to Go 1.22 since the project update go.mod to 1.22.