### PR TITLE
Add `org.opencontainers.image.source` metadata LABEL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN go build \
 RUN strip /bin/action
 
 FROM scratch
+LABEL org.opencontainers.image.source=https://github.com/buildpacks/github-actions
 COPY --from=build-stage /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build-stage /bin/action /bin/action
 ENTRYPOINT ["/bin/action"]


### PR DESCRIPTION
So that the images published to the GitHub Container Registry are associated with this GitHub repo - and so show up under a "Packages" tab on this repo, rather than only under the generic "Packages" view for the org:
https://github.com/orgs/buildpacks/packages

See:

- https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images
- https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package#connecting-a-repository-to-a-container-image-using-the-command-line