### PR TITLE
Replace example tag versions in README with placeholder values

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ The `setup-pack` action adds [`pack`][pack] to the environment.
 [pack]:  https://github.com/buildpacks/pack
 
 ```yaml
-uses: buildpacks/github-actions/setup-pack@v5.0.0
+uses: buildpacks/github-actions/setup-pack@vX.Y.Z
 ```
 
 #### Inputs <!-- omit in toc -->
@@ -223,7 +223,7 @@ The `setup-tools` action adds [crane][crane] and [`yj`][yj] to the environment.
 [yj]:    https://github.com/sclevine/yj
 
 ```yaml
-uses: buildpacks/github-actions/setup-tools@v5.0.0
+uses: buildpacks/github-actions/setup-tools@vX.Y.Z
 ```
 
 #### Inputs <!-- omit in toc -->


### PR DESCRIPTION
Since the current examples use `v5.0.0` which is old and leads to eg: https://github.com/buildpacks/github-actions/issues/376

Ideally we'd have a `v5` branch/tag alias per #271, but in lieu of that I think it's best to use placeholder values rather than a version that's going to get stale over time.