### PR TITLE
feat(setup-pack): add pack-version-file input and verify download checksum

### DIFF
--- a/.github/workflows/update-pack-version.yml
+++ b/.github/workflows/update-pack-version.yml
@@ -18,15 +18,15 @@ jobs:
             echo "new_version=${NEW_VERSION}" >> ${GITHUB_OUTPUT}
       - name: Update setup-pack/action.yml with the new Pack version
         run: |
-            sed -i -z "s/default:     '[0-9]\{1,\}.[0-9]\{1,\}.[0-9]\{1,\}'/default:     '${{ steps.version.outputs.new_version }}'/" setup-pack/action.yml
+            sed -i "s/FALLBACK_PACK_VERSION: '[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}'/FALLBACK_PACK_VERSION: '${{ steps.version.outputs.new_version }}'/" setup-pack/action.yml
       - name: Create pull request
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.DISTRIBUTION_GITHUB_TOKEN }}
-          commit-message: Update default Pack version to v${{ steps.version.outputs.new_version }}
-          title: Update default Pack version to v${{ steps.version.outputs.new_version }}
+          commit-message: Update fallback Pack version to v${{ steps.version.outputs.new_version }}
+          title: Update fallback Pack version to v${{ steps.version.outputs.new_version }}
           body: |
-            Updates the `setup-pack` action's default `pack-version` to the latest Pack release.
+            Updates the `setup-pack` action's fallback `pack-version` to the latest Pack release.
             
             Release notes:
             https://github.com/buildpacks/pack/releases/tag/v${{ steps.version.outputs.new_version }}

--- a/.github/workflows/update-pack-version.yml
+++ b/.github/workflows/update-pack-version.yml
@@ -18,15 +18,15 @@ jobs:
             echo "new_version=${NEW_VERSION}" >> ${GITHUB_OUTPUT}
       - name: Update setup-pack/action.yml with the new Pack version
         run: |
-            sed -i "s/FALLBACK_PACK_VERSION: '[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}'/FALLBACK_PACK_VERSION: '${{ steps.version.outputs.new_version }}'/" setup-pack/action.yml
+            sed -i "s/DEFAULT_PACK_VERSION: '[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}'/DEFAULT_PACK_VERSION: '${{ steps.version.outputs.new_version }}'/" setup-pack/action.yml
       - name: Create pull request
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.DISTRIBUTION_GITHUB_TOKEN }}
-          commit-message: Update fallback Pack version to v${{ steps.version.outputs.new_version }}
-          title: Update fallback Pack version to v${{ steps.version.outputs.new_version }}
+          commit-message: Update default Pack version to v${{ steps.version.outputs.new_version }}
+          title: Update default Pack version to v${{ steps.version.outputs.new_version }}
           body: |
-            Updates the `setup-pack` action's fallback `pack-version` to the latest Pack release.
+            Updates the `setup-pack` action's default `pack-version` to the latest Pack release.
             
             Release notes:
             https://github.com/buildpacks/pack/releases/tag/v${{ steps.version.outputs.new_version }}

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ the action warns and proceeds.
 #### Inputs <!-- omit in toc -->
 | Parameter | Description
 | :-------- | :----------
-| `pack-version` | Optional version of [`pack`][pack] to install. Takes precedence over `pack-version-file` when both are set. Defaults to a pinned fallback version.
+| `pack-version` | Optional version of [`pack`][pack] to install. Takes precedence over `pack-version-file` when both are set. Defaults to a pinned version.
 | `pack-version-file` | Optional path to a file (`.tool-versions` or a plain version file) holding the [`pack`][pack] version. Used only when `pack-version` is not set.
 
 ## Setup Tools Action

--- a/README.md
+++ b/README.md
@@ -214,12 +214,8 @@ uses: buildpacks/github-actions/setup-pack@vX.Y.Z
 The version can also be kept in a file and referenced with the
 `pack-version-file` input. Both a `.tool-versions` file (the `pack` entry is
 read) and a plain version file like `.pack-version` are supported. When both
-`pack-version` and `pack-version-file` are set, `pack-version` takes precedence
-(matching the [`setup-go`][setup-go-version-file] `go-version` /
-`go-version-file` convention). When neither is set, a pinned fallback version
-is used.
-
-[setup-go-version-file]: https://github.com/actions/setup-go/blob/main/docs/advanced-usage.md#using-the-go-version-file-input
+`pack-version` and `pack-version-file` are set, `pack-version` takes precedence.
+When neither is set, a pinned default version is used.
 
 ```yaml
 uses: buildpacks/github-actions/setup-pack@vX.Y.Z

--- a/README.md
+++ b/README.md
@@ -211,10 +211,26 @@ The `setup-pack` action adds [`pack`][pack] to the environment.
 uses: buildpacks/github-actions/setup-pack@vX.Y.Z
 ```
 
+The version can also be kept in a file and referenced with the
+`pack-version-file` input. Both a `.tool-versions` file (the `pack` entry is
+read) and a plain version file like `.pack-version` are supported. When
+`pack-version-file` is set it takes precedence over `pack-version`.
+
+```yaml
+uses: buildpacks/github-actions/setup-pack@vX.Y.Z
+with:
+  pack-version-file: '.tool-versions'
+```
+
+The downloaded archive is verified against the release's published
+`<asset>.sha256` checksum before extraction. If the checksum cannot be fetched,
+the action warns and proceeds.
+
 #### Inputs <!-- omit in toc -->
 | Parameter | Description
 | :-------- | :----------
 | `pack-version` | Optional version of [`pack`][pack] to install. Defaults to latest release.
+| `pack-version-file` | Optional path to a file (`.tool-versions` or a plain version file) holding the [`pack`][pack] version. Takes precedence over `pack-version`.
 
 ## Setup Tools Action
 The `setup-tools` action adds [crane][crane] and [`yj`][yj] to the environment.

--- a/README.md
+++ b/README.md
@@ -213,8 +213,13 @@ uses: buildpacks/github-actions/setup-pack@vX.Y.Z
 
 The version can also be kept in a file and referenced with the
 `pack-version-file` input. Both a `.tool-versions` file (the `pack` entry is
-read) and a plain version file like `.pack-version` are supported. When
-`pack-version-file` is set it takes precedence over `pack-version`.
+read) and a plain version file like `.pack-version` are supported. When both
+`pack-version` and `pack-version-file` are set, `pack-version` takes precedence
+(matching the [`setup-go`][setup-go-version-file] `go-version` /
+`go-version-file` convention). When neither is set, a pinned fallback version
+is used.
+
+[setup-go-version-file]: https://github.com/actions/setup-go/blob/main/docs/advanced-usage.md#using-the-go-version-file-input
 
 ```yaml
 uses: buildpacks/github-actions/setup-pack@vX.Y.Z
@@ -229,8 +234,8 @@ the action warns and proceeds.
 #### Inputs <!-- omit in toc -->
 | Parameter | Description
 | :-------- | :----------
-| `pack-version` | Optional version of [`pack`][pack] to install. Defaults to latest release.
-| `pack-version-file` | Optional path to a file (`.tool-versions` or a plain version file) holding the [`pack`][pack] version. Takes precedence over `pack-version`.
+| `pack-version` | Optional version of [`pack`][pack] to install. Takes precedence over `pack-version-file` when both are set. Defaults to a pinned fallback version.
+| `pack-version-file` | Optional path to a file (`.tool-versions` or a plain version file) holding the [`pack`][pack] version. Used only when `pack-version` is not set.
 
 ## Setup Tools Action
 The `setup-tools` action adds [crane][crane] and [`yj`][yj] to the environment.

--- a/setup-pack/action.yml
+++ b/setup-pack/action.yml
@@ -48,13 +48,17 @@ runs:
 
              case "$(basename "${PACK_VERSION_FILE}")" in
                .tool-versions)
-                 # asdf/mise format, e.g. `pack 0.40.6` (extra fields and comments are ignored)
-                 version="$(grep -E '^pack[[:space:]]+' "${PACK_VERSION_FILE}" | head -n1 | awk '{print $2}')"
+                 # asdf/mise format, e.g. `pack 0.40.6` (extra fields and comments are ignored).
+                 # awk (not grep|head) so a file with no `pack` entry yields an empty
+                 # version and reaches the guard below instead of aborting under pipefail.
+                 version="$(awk '$1 == "pack" { print $2; exit }' "${PACK_VERSION_FILE}")"
                  ;;
                *)
                  # Plain version file: first non-empty, non-comment line, with
                  # any inline trailing comment (e.g. `0.40.6 # pinned`) stripped.
-                 version="$(grep -vE '^[[:space:]]*(#|$)' "${PACK_VERSION_FILE}" | head -n1 | sed 's/#.*//' | tr -d '[:space:]')"
+                 # `|| true` so an all-comment/empty file yields an empty version
+                 # and reaches the guard below instead of aborting under pipefail.
+                 version="$(grep -vE '^[[:space:]]*(#|$)' "${PACK_VERSION_FILE}" | head -n1 | sed 's/#.*//' | tr -d '[:space:]')" || true
                  ;;
              esac
 

--- a/setup-pack/action.yml
+++ b/setup-pack/action.yml
@@ -16,10 +16,6 @@ inputs:
       file like .pack-version (the first non-comment line is read). Used only
       when pack-version is not set.
     required:    false
-<<<<<<< feat/setup-pack-version-file-checksum
-=======
-    default:     '0.40.8'
->>>>>>> main
 
 runs:
   using: "composite"
@@ -33,7 +29,7 @@ runs:
       # Default pack version, used only when neither pack-version nor
       # pack-version-file is set. Kept current by the update-pack-version
       # workflow (which rewrites the value below).
-      DEFAULT_PACK_VERSION: '0.40.7'
+      DEFAULT_PACK_VERSION: '0.40.8'
     run:   |
            #!/usr/bin/env bash
 

--- a/setup-pack/action.yml
+++ b/setup-pack/action.yml
@@ -6,9 +6,8 @@ inputs:
   pack-version:
     description: >-
       The version of pack to install. When both pack-version and
-      pack-version-file are set, pack-version takes precedence (matching the
-      setup-go go-version/go-version-file convention). When neither is set, a
-      pinned fallback version is used.
+      pack-version-file are set, pack-version takes precedence. When neither is
+      set, a pinned default version is used.
     required:    false
   pack-version-file:
     description: >-

--- a/setup-pack/action.yml
+++ b/setup-pack/action.yml
@@ -7,12 +7,63 @@ inputs:
     description: 'The version of pack to install'
     required:    false
     default:     '0.40.7'
+  pack-version-file:
+    description: >-
+      Path to a file that contains the pack version to install, such as a
+      .tool-versions file (the `pack <version>` entry is read) or a plain
+      file like .pack-version (the first non-comment line is read). When set,
+      it takes precedence over pack-version.
+    required:    false
 
 runs:
   using: "composite"
   steps:
+  - name:  Resolve pack version
+    id:    resolve
+    shell: bash
+    env:
+      PACK_VERSION:      ${{ inputs.pack-version }}
+      PACK_VERSION_FILE: ${{ inputs.pack-version-file }}
+    run:   |
+           #!/usr/bin/env bash
+
+           set -euo pipefail
+
+           version="${PACK_VERSION}"
+
+           if [ -n "${PACK_VERSION_FILE}" ]; then
+             if [ ! -f "${PACK_VERSION_FILE}" ]; then
+               echo "::error::pack-version-file '${PACK_VERSION_FILE}' does not exist"
+               exit 1
+             fi
+
+             case "$(basename "${PACK_VERSION_FILE}")" in
+               .tool-versions)
+                 # asdf/mise format, e.g. `pack 0.40.6` (extra fields and comments are ignored)
+                 version="$(grep -E '^pack[[:space:]]+' "${PACK_VERSION_FILE}" | head -n1 | awk '{print $2}')"
+                 ;;
+               *)
+                 # Plain version file: first non-empty, non-comment line
+                 version="$(grep -vE '^[[:space:]]*(#|$)' "${PACK_VERSION_FILE}" | head -n1 | tr -d '[:space:]')"
+                 ;;
+             esac
+
+             if [ -z "${version}" ]; then
+               echo "::error::could not determine a pack version from '${PACK_VERSION_FILE}'"
+               exit 1
+             fi
+
+             # Tolerate an optional leading `v` in the file (e.g. `v0.40.6`).
+             version="${version#v}"
+             echo "Resolved pack version '${version}' from '${PACK_VERSION_FILE}'"
+           fi
+
+           echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
   - name:  Install pack CLI
     shell: bash
+    env:
+      PACK_VERSION: ${{ steps.resolve.outputs.version }}
     run:   |
            #!/usr/bin/env bash
 
@@ -22,12 +73,17 @@ runs:
            echo "PATH=${HOME}/bin:${PATH}" >> "${GITHUB_ENV}"
 
            PLATFORM="linux"
-           if [ $(arch) = "aarch64" ]; then
+           if [ "$(arch)" = "aarch64" ]; then
               PLATFORM="linux-arm64"
            fi
 
-           PACK_VERSION=${{ inputs.pack-version }}
            echo "Installing pack ${PACK_VERSION}"
+
+           BASE_URL="https://github.com/buildpacks/pack/releases/download/v${PACK_VERSION}"
+           ASSET="pack-v${PACK_VERSION}-${PLATFORM}.tgz"
+           TMP="$(mktemp -d)"
+           trap 'rm -rf "${TMP}"' EXIT
+
            curl \
              --show-error \
              --silent \
@@ -36,5 +92,31 @@ runs:
              --retry 3 \
              --connect-timeout 5 \
              --max-time 60 \
-             "https://github.com/buildpacks/pack/releases/download/v${PACK_VERSION}/pack-v${PACK_VERSION}-${PLATFORM}.tgz" \
-           | tar -C "${HOME}/bin" -xz pack
+             --output "${TMP}/${ASSET}" \
+             "${BASE_URL}/${ASSET}"
+
+           # Verify the download against the release's published SHA256 checksum.
+           # Each asset is published with a sibling <asset>.sha256 file. If it
+           # cannot be fetched (e.g. a mirror that does not host it), warn and
+           # proceed so existing setups are not broken.
+           if EXPECTED="$(curl \
+                 --show-error \
+                 --silent \
+                 --location \
+                 --fail \
+                 --retry 3 \
+                 --connect-timeout 5 \
+                 --max-time 60 \
+                 "${BASE_URL}/${ASSET}.sha256" | awk '{print $1}')" \
+              && [ -n "${EXPECTED}" ]; then
+             ACTUAL="$(sha256sum "${TMP}/${ASSET}" | awk '{print $1}')"
+             if [ "${EXPECTED}" != "${ACTUAL}" ]; then
+               echo "::error::checksum mismatch for ${ASSET} (expected ${EXPECTED}, got ${ACTUAL})"
+               exit 1
+             fi
+             echo "Verified ${ASSET} against the published SHA256 checksum"
+           else
+             echo "::warning::could not fetch ${ASSET}.sha256; skipping checksum verification"
+           fi
+
+           tar -C "${HOME}/bin" -xzf "${TMP}/${ASSET}" pack

--- a/setup-pack/action.yml
+++ b/setup-pack/action.yml
@@ -4,15 +4,18 @@ author:      'Cloud Native Buildpacks'
 
 inputs:
   pack-version:
-    description: 'The version of pack to install'
+    description: >-
+      The version of pack to install. When both pack-version and
+      pack-version-file are set, pack-version takes precedence (matching the
+      setup-go go-version/go-version-file convention). When neither is set, a
+      pinned fallback version is used.
     required:    false
-    default:     '0.40.7'
   pack-version-file:
     description: >-
       Path to a file that contains the pack version to install, such as a
       .tool-versions file (the `pack <version>` entry is read) or a plain
-      file like .pack-version (the first non-comment line is read). When set,
-      it takes precedence over pack-version.
+      file like .pack-version (the first non-comment line is read). Used only
+      when pack-version is not set.
     required:    false
 
 runs:
@@ -22,16 +25,22 @@ runs:
     id:    resolve
     shell: bash
     env:
-      PACK_VERSION:      ${{ inputs.pack-version }}
-      PACK_VERSION_FILE: ${{ inputs.pack-version-file }}
+      PACK_VERSION:          ${{ inputs.pack-version }}
+      PACK_VERSION_FILE:     ${{ inputs.pack-version-file }}
+      # Fallback pack version, used only when neither pack-version nor
+      # pack-version-file is set. Kept current by the update-pack-version
+      # workflow (which rewrites the value below).
+      FALLBACK_PACK_VERSION: '0.40.7'
     run:   |
            #!/usr/bin/env bash
 
            set -euo pipefail
 
-           version="${PACK_VERSION}"
-
-           if [ -n "${PACK_VERSION_FILE}" ]; then
+           if [ -n "${PACK_VERSION}" ]; then
+             # An explicit pack-version always wins, even if pack-version-file is
+             # also set (matches setup-go's go-version vs go-version-file rule).
+             version="${PACK_VERSION}"
+           elif [ -n "${PACK_VERSION_FILE}" ]; then
              if [ ! -f "${PACK_VERSION_FILE}" ]; then
                echo "::error::pack-version-file '${PACK_VERSION_FILE}' does not exist"
                exit 1
@@ -43,8 +52,9 @@ runs:
                  version="$(grep -E '^pack[[:space:]]+' "${PACK_VERSION_FILE}" | head -n1 | awk '{print $2}')"
                  ;;
                *)
-                 # Plain version file: first non-empty, non-comment line
-                 version="$(grep -vE '^[[:space:]]*(#|$)' "${PACK_VERSION_FILE}" | head -n1 | tr -d '[:space:]')"
+                 # Plain version file: first non-empty, non-comment line, with
+                 # any inline trailing comment (e.g. `0.40.6 # pinned`) stripped.
+                 version="$(grep -vE '^[[:space:]]*(#|$)' "${PACK_VERSION_FILE}" | head -n1 | sed 's/#.*//' | tr -d '[:space:]')"
                  ;;
              esac
 
@@ -56,6 +66,8 @@ runs:
              # Tolerate an optional leading `v` in the file (e.g. `v0.40.6`).
              version="${version#v}"
              echo "Resolved pack version '${version}' from '${PACK_VERSION_FILE}'"
+           else
+             version="${FALLBACK_PACK_VERSION}"
            fi
 
            echo "version=${version}" >> "${GITHUB_OUTPUT}"

--- a/setup-pack/action.yml
+++ b/setup-pack/action.yml
@@ -27,10 +27,10 @@ runs:
     env:
       PACK_VERSION:          ${{ inputs.pack-version }}
       PACK_VERSION_FILE:     ${{ inputs.pack-version-file }}
-      # Fallback pack version, used only when neither pack-version nor
+      # Default pack version, used only when neither pack-version nor
       # pack-version-file is set. Kept current by the update-pack-version
       # workflow (which rewrites the value below).
-      FALLBACK_PACK_VERSION: '0.40.7'
+      DEFAULT_PACK_VERSION: '0.40.7'
     run:   |
            #!/usr/bin/env bash
 
@@ -71,7 +71,7 @@ runs:
              version="${version#v}"
              echo "Resolved pack version '${version}' from '${PACK_VERSION_FILE}'"
            else
-             version="${FALLBACK_PACK_VERSION}"
+             version="${DEFAULT_PACK_VERSION}"
            fi
 
            echo "version=${version}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
The `setup-pack` action only accepted an explicit `pack-version`, and it piped the downloaded archive straight into `tar` with no integrity check. This adds two things:

1. A `pack-version-file` input that reads the version from a `.tool-versions` file (the `pack` entry) or a plain version file like `.pack-version`. Version resolution is now `pack-version` → `pack-version-file` → a pinned default, so an explicit `pack-version` always wins even when `pack-version-file` is also set — matching the `setup-go` `go-version` / `go-version-file` convention.
2. Default-on SHA256 verification. Each pack release publishes a sibling `<asset>.sha256`, so the action now downloads the archive to a temp file, verifies it against that checksum, and only then extracts. If the checksum cannot be fetched it warns and proceeds, so mirror / air-gapped setups are not broken.

### ⚠️ Breaking change (major version bump)

To make the precedence above work, the `pack-version` **input default was removed**. `setup-go` can treat an empty `go-version` as "unset", but `pack-version` always carried a default, so a composite action could not tell "user asked for the default" from "defaulted" — which made `pack-version-file` unreachable whenever a default was present. The default is now a `DEFAULT_PACK_VERSION` in the step `env:` block, used only when neither input is set, and the `update-pack-version` workflow's `sed` is re-pointed at that line so the auto-bump keeps working.

Runtime behavior is unchanged for existing users (with nothing set, the pinned default is unchanged). But removing the input default is an API change, so this should land as a **major version bump**.

### Validation

Done locally (the repo has no composite-action test harness, only the Go unit tests):

* Version resolution covered: precedence (both set → inline wins / file-only / neither → default), `.tool-versions` with a `pack` entry (tab separated + trailing comment), plain version file (leading `v`, blank/comment lines, **and inline trailing comment** like `0.40.6 # pinned`), and missing-file error.
* Checksum path verified end to end against a real linux asset: a matching sum passes, a corrupted archive is rejected, and `tar` member extraction still yields the `pack` binary.
* Re-pointed `update-pack-version` `sed` re-verified against the new `DEFAULT_PACK_VERSION:` env line.
* `shellcheck` clean on both inline scripts.

