### PR TITLE
chore(deps): upgrade github.com/pelletier/go-toml to v2

### DIFF
--- a/buildpack/compute-metadata/compute_metadata.go
+++ b/buildpack/compute-metadata/compute_metadata.go
@@ -21,7 +21,7 @@ import (
 	"io/ioutil"
 
 	"github.com/buildpacks/libcnb"
-	"github.com/pelletier/go-toml"
+	"github.com/pelletier/go-toml/v2"
 
 	"github.com/buildpacks/github-actions/internal/toolkit"
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/go-containerregistry v0.21.7
 	github.com/google/go-github/v39 v39.2.0
 	github.com/onsi/gomega v1.42.1
-	github.com/pelletier/go-toml v1.9.5
+	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/sclevine/spec v1.4.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/oauth2 v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
-github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
+github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
+github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a h1:3QH7VyOaaiUHNrA9Se4YQIRkDTCw1EJls9xTUCaCeRM=

--- a/registry/compute-metadata/compute_metadata.go
+++ b/registry/compute-metadata/compute_metadata.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/google/go-github/v39/github"
-	"github.com/pelletier/go-toml"
+	"github.com/pelletier/go-toml/v2"
 
 	"github.com/buildpacks/github-actions/internal/toolkit"
 	"github.com/buildpacks/github-actions/registry/internal/index"

--- a/registry/compute-metadata/compute_metadata_test.go
+++ b/registry/compute-metadata/compute_metadata_test.go
@@ -23,12 +23,12 @@ import (
 
 	"github.com/google/go-github/v39/github"
 	. "github.com/onsi/gomega"
-	"github.com/pelletier/go-toml"
+	"github.com/pelletier/go-toml/v2"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 
 	"github.com/buildpacks/github-actions/internal/toolkit"
-	"github.com/buildpacks/github-actions/registry/compute-metadata"
+	metadata "github.com/buildpacks/github-actions/registry/compute-metadata"
 	"github.com/buildpacks/github-actions/registry/internal/index"
 )
 
@@ -130,6 +130,5 @@ func TestComputeMetadata(t *testing.T) {
 
 			Expect(metadata.ComputeMetadata(tk)).To(Succeed())
 		})
-
 	}, spec.Report(report.Terminal{}))
 }

--- a/registry/request-add-entry/request_add_entry.go
+++ b/registry/request-add-entry/request_add_entry.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"github.com/google/go-github/v39/github"
-	"github.com/pelletier/go-toml"
+	"github.com/pelletier/go-toml/v2"
 	"gopkg.in/retry.v1"
 
 	"github.com/buildpacks/github-actions/internal/toolkit"

--- a/registry/request-add-entry/request_add_entry_test.go
+++ b/registry/request-add-entry/request_add_entry_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/go-github/v39/github"
 	. "github.com/onsi/gomega"
-	"github.com/pelletier/go-toml"
+	"github.com/pelletier/go-toml/v2"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/mock"
@@ -31,7 +31,7 @@ import (
 	"github.com/buildpacks/github-actions/internal/toolkit"
 	"github.com/buildpacks/github-actions/registry/internal/index"
 	"github.com/buildpacks/github-actions/registry/internal/services"
-	"github.com/buildpacks/github-actions/registry/request-add-entry"
+	entry "github.com/buildpacks/github-actions/registry/request-add-entry"
 )
 
 func TestRequestAddEntry(t *testing.T) {
@@ -81,6 +81,5 @@ func TestRequestAddEntry(t *testing.T) {
 			Expect(entry.RequestAddEntry(tk, i, s)).
 				To(MatchError("::error ::Registry request test-html-url failed"))
 		})
-
 	}, spec.Report(report.Terminal{}))
 }

--- a/registry/request-yank-entry/request_yank_entry.go
+++ b/registry/request-yank-entry/request_yank_entry.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"github.com/google/go-github/v39/github"
-	"github.com/pelletier/go-toml"
+	"github.com/pelletier/go-toml/v2"
 	"gopkg.in/retry.v1"
 
 	"github.com/buildpacks/github-actions/internal/toolkit"

--- a/registry/request-yank-entry/request_yank_entry_test.go
+++ b/registry/request-yank-entry/request_yank_entry_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/go-github/v39/github"
 	. "github.com/onsi/gomega"
-	"github.com/pelletier/go-toml"
+	"github.com/pelletier/go-toml/v2"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/mock"
@@ -31,7 +31,7 @@ import (
 	"github.com/buildpacks/github-actions/internal/toolkit"
 	"github.com/buildpacks/github-actions/registry/internal/index"
 	"github.com/buildpacks/github-actions/registry/internal/services"
-	"github.com/buildpacks/github-actions/registry/request-yank-entry"
+	entry "github.com/buildpacks/github-actions/registry/request-yank-entry"
 )
 
 func TestRequestYankEntry(t *testing.T) {
@@ -80,6 +80,5 @@ func TestRequestYankEntry(t *testing.T) {
 			Expect(entry.RequestYankEntry(tk, i, s)).
 				To(MatchError("::error ::Registry request test-html-url failed"))
 		})
-
 	}, spec.Report(report.Terminal{}))
 }


### PR DESCRIPTION
Upgrade the `github.com/pelletier/go-toml` from `v1` to `v2`.